### PR TITLE
Initialize a Firebase project in your directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ plugins: [require("daisyui")],
 ```shell
 npm install  firebase
 ```
-2. Deploy your project to Firebase by running the following command:
+2. Initialize a Firebase project in your director:
+```shell
+firebase init
+```
+
+3. Deploy your project to Firebase by running the following command:
 ```shell
 firebase deploy
 ```


### PR DESCRIPTION
Before deploying to firebase, one needs to initialize a firebase project by the command 'firebase init'

 If you are in a Firebase app directory, the command will ask you to select a project to connect to. If you are not in a Firebase app directory, the command will create a new Firebase app directory for you.